### PR TITLE
WIP: Allow dynamic handler type

### DIFF
--- a/src/collect.rs
+++ b/src/collect.rs
@@ -188,6 +188,7 @@ macro_rules! consume_linear_space {
     ($context:expr, $on_eos:expr) => ({
         bs_available!($context) > 0 || $on_eos;
 
+        #[allow(unused_unsafe)]
         unsafe {
             if bs_starts_with1!($context, b" ") || bs_starts_with1!($context, b"\t") {
                 loop {

--- a/src/fsm.rs
+++ b/src/fsm.rs
@@ -54,9 +54,8 @@ macro_rules! callback_eos_expr {
 /// Execute callback `$callback` ignoring the last collected byte. If it returns `true`, transition
 /// to `$state`. Otherwise exit with `Success::Callback`.
 macro_rules! callback_ignore_transition {
-    ($parser:expr, $handler:expr, $context:expr, $callback:ident, $state:ident,
-     $state_function:ident) => ({
-        set_state!($parser, $state, $state_function);
+    ($parser:expr, $handler:expr, $context:expr, $callback:ident, $state:ident) => ({
+        set_state!($parser, $state);
 
         // compare against 1 instead of 0 because we're ignoring the last slice byte
         if bs_slice_length!($context) > 1 {
@@ -77,17 +76,15 @@ macro_rules! callback_ignore_transition {
 /// This macro exists to enforce the design decision that after each callback, state must either
 /// change, or the parser must exit with `Success::Callback`.
 macro_rules! callback_transition {
-    ($parser:expr, $handler:expr, $context:expr, $callback:ident, $data:expr, $state:ident,
-     $state_function:ident) => ({
-        set_state!($parser, $state, $state_function);
+    ($parser:expr, $handler:expr, $context:expr, $callback:ident, $data:expr, $state:ident) => ({
+        set_state!($parser, $state);
         callback!($parser, $handler, $context, $callback, $data, {
             transition!($parser, $context);
         });
     });
 
-    ($parser:expr, $handler:expr, $context:expr, $callback:ident, $state:ident,
-     $state_function:ident) => ({
-        set_state!($parser, $state, $state_function);
+    ($parser:expr, $handler:expr, $context:expr, $callback:ident, $state:ident) => ({
+        set_state!($parser, $state);
         callback!($parser, $handler, $context, $callback, {
             transition!($parser, $context);
         });
@@ -96,8 +93,8 @@ macro_rules! callback_transition {
 
 /// Exit parser with `Success::Callback`.
 macro_rules! exit_callback {
-    ($parser:expr, $context:expr, $state:ident, $state_function:ident) => ({
-        set_state!($parser, $state, $state_function);
+    ($parser:expr, $context:expr, $state:ident) => ({
+        set_state!($parser, $state);
 
         return Ok(ParserValue::Exit(Success::Callback($context.stream_index)));
     });
@@ -148,16 +145,15 @@ macro_rules! get_state {
 
 /// Set state and state function.
 macro_rules! set_state {
-    ($parser:expr, $state:ident, $state_function:ident) => ({
+    ($parser:expr, $state:ident) => ({
         $parser.state          = ParserState::$state;
-        $parser.state_function = Parser::$state_function;
     });
 }
 
 /// Transition to `$state`.
 macro_rules! transition {
-    ($parser:expr, $context:expr, $state:ident, $state_function:ident) => ({
-        set_state!($parser, $state, $state_function);
+    ($parser:expr, $context:expr, $state:ident) => ({
+        set_state!($parser, $state);
 
         bs_mark!($context, $context.stream_index);
 
@@ -175,8 +171,8 @@ macro_rules! transition {
 ///
 /// This will not readjust the mark index.
 macro_rules! transition_no_remark {
-    ($parser:expr, $context:expr, $state:ident, $state_function:ident) => ({
-        set_state!($parser, $state, $state_function);
+    ($parser:expr, $context:expr, $state:ident) => ({
+        set_state!($parser, $state);
 
         return Ok(ParserValue::Continue);
     });

--- a/src/http1/test/mod.rs
+++ b/src/http1/test/mod.rs
@@ -26,7 +26,7 @@ macro_rules! http1_setup {
 }
 
 fn assert_callback<T: HttpHandler>(
-    parser:  &mut Parser<T>,
+    parser:  &mut Parser,
     handler: &mut T,
     stream:  &[u8],
     state:   ParserState,
@@ -42,7 +42,7 @@ fn assert_callback<T: HttpHandler>(
 }
 
 fn assert_eos<T: HttpHandler>(
-    parser:  &mut Parser<T>,
+    parser:  &mut Parser,
     handler: &mut T,
     stream:  &[u8],
     state:   ParserState,
@@ -58,7 +58,7 @@ fn assert_eos<T: HttpHandler>(
 }
 
 fn assert_error<T: HttpHandler>(
-    parser:  &mut Parser<T>,
+    parser:  &mut Parser,
     handler: &mut T,
     stream:  &[u8],
     error:   ParserError
@@ -68,12 +68,12 @@ fn assert_error<T: HttpHandler>(
             assert_eq!(error, error_);
             assert_eq!(ParserState::Dead, parser.state());
         },
-        _ => panic!("assert_error() Err() match failed")
+        res => panic!("assert_error() Err() match failed: {:?}", res)
     }
 }
 
 fn iter_assert_eos<T: HttpHandler>(
-    parser:  &mut Parser<T>,
+    parser:  &mut Parser,
     handler: &mut T,
     details: &[(u8, ParserState)]
 ) {
@@ -94,7 +94,7 @@ fn iter_assert_eos<T: HttpHandler>(
 }
 
 fn assert_finished<T: HttpHandler>(
-    parser:  &mut Parser<T>,
+    parser:  &mut Parser,
     handler: &mut T,
     stream:  &[u8],
     length:  usize

--- a/src/http1/test/request/method.rs
+++ b/src/http1/test/request/method.rs
@@ -102,6 +102,10 @@ fn not_allowed_error() {
     for b in (0..0x41).chain(0x5B..0xFF) {
         let (mut p, mut h) = setup!();
 
+        if b"\r\n\t ".contains(&b) {
+            continue;
+        }
+
         assert_error(
             &mut p,
             &mut h,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,7 @@ mod collect;
 
 pub mod byte;
 pub mod http1;
-pub mod http2;
+// pub mod http2;
 pub mod util;
 
 #[cfg(test)]

--- a/src/util/decode.rs
+++ b/src/util/decode.rs
@@ -96,7 +96,7 @@ impl fmt::Display for DecodeError {
 /// ```
 pub fn decode(encoded: &[u8]) -> Result<String, DecodeError> {
     macro_rules! submit {
-        ($string:expr, $slice:expr) => (unsafe {
+        ($string:expr, $slice:expr) => (#[allow(unused_unsafe)] unsafe {
             $string.as_mut_vec().extend_from_slice($slice);
         });
     }


### PR DESCRIPTION
Remove the `<T: HttpHandler>` type parameter from the `Parser` struct and move it to the individual methods. This allows for supplying the handler on demand, for example with references to the environment.

This patch requires some cleaning up and restructuring (there are a few things pub which should at most be `pub(restricted)`) and http2 also still needs updating, however I wanted to get some initial feedback on the approach taken (also the diff is probably better right now, since fixing the `pub` issue would likely require moving some files around).

Note: I recommend the diff with whitespace changes ignored: https://github.com/seankerr/rust-http-box/compare/master...TimNN:dynamic-handler?w=1